### PR TITLE
`os.tmpdir` doesn’t exist in node 0.8

### DIFF
--- a/eval-markdown.js
+++ b/eval-markdown.js
@@ -1,4 +1,4 @@
-var os = require('os')
+var osTmpDir = require('os-tmpdir')
 var crypto = require('crypto')
 var path = require('path')
 var Promise = require('bluebird')
@@ -13,7 +13,7 @@ var promiseRipple = require('./promise-ripple')
 var promiseSeries = require('./promise-series')
 // var _eval = require('eval')
 var chalk = require('chalk')
-var temp = path.join(os.tmpdir(), 'evalmd')
+var temp = path.join(osTmpDir(), 'evalmd')
 
 var log = false
 var DEBUG = false

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "fs-extra": "reggi/node-fs-extra#enhanced",
     "lodash": "^3.10.0",
     "markdown-it": "markdown-it/markdown-it#255d62d39122694872ddce840e2141379ac3deca",
+    "os-tmpdir": "^1.0.1",
     "underscore.string": "^3.1.1",
     "yargs": "^3.19.0"
   },


### PR DESCRIPTION
This will make `evalmd` work in node `0.8`.